### PR TITLE
Bash-it deprecation: vagrant plugin is now a completion

### DIFF
--- a/soloistrc.C02RP63SG8WP
+++ b/soloistrc.C02RP63SG8WP
@@ -82,7 +82,6 @@ node_attributes:
         - osx
         - rvm
         - ssh
-        - vagrant
       aliases:
         - ag
         - bundler
@@ -99,6 +98,7 @@ node_attributes:
         - rake
         - ssh
         - tmux
+        - vagrant
     custom_plugins:
       sprout-base:
         - bash_it/custom/disable_ctrl-s_output_control.bash

--- a/soloistrc.lyra
+++ b/soloistrc.lyra
@@ -110,7 +110,6 @@ node_attributes:
         - osx
         - rvm
         - ssh
-        - vagrant
       aliases:
         - ag
         - bundler
@@ -127,6 +126,7 @@ node_attributes:
         - rake
         - ssh
         - tmux
+        - vagrant
     custom_plugins:
       sprout-base:
         - bash_it/custom/disable_ctrl-s_output_control.bash

--- a/soloistrc.rpco-jcuzel1407
+++ b/soloistrc.rpco-jcuzel1407
@@ -69,7 +69,6 @@ node_attributes:
         - osx
         - rvm
         - ssh
-        - vagrant
       aliases:
         - ag
         - bundler
@@ -86,6 +85,7 @@ node_attributes:
         - rake
         - ssh
         - tmux
+        - vagrant
     custom_plugins:
       sprout-base:
         - bash_it/custom/disable_ctrl-s_output_control.bash

--- a/test/fixtures/soloistrc
+++ b/test/fixtures/soloistrc
@@ -68,6 +68,7 @@ node_attributes:
         - tmux
         - travis
         - vault
+        - vagrant
     custom_plugins:
       sprout-base:
         - bash_it/custom/disable_ctrl-s_output_control.bash


### PR DESCRIPTION
Changed in Bash-it/bash-it@fedb24e