### PR TITLE
bootstrap.sh: Allow passing custom SOLOISTRC via env var

### DIFF
--- a/bootstrap-scripts/bootstrap.sh
+++ b/bootstrap-scripts/bootstrap.sh
@@ -67,6 +67,7 @@ if [[ "$CI" == 'true' ]]; then
 fi
 
 use_system_ruby=0
+SOLOISTRC=${SOLOISTRC:-soloistrc}
 SOLOIST_DIR=${SOLOIST_DIR:-"${HOME}/src/pub/soloist"}
 #XCODE_DMG='XCode-4.6.3-4H1503.dmg'
 SPROUT_WRAP_URL='https://github.com/LyraPhase/sprout-wrap.git'
@@ -316,6 +317,15 @@ if ! bundle check 2>&1 >/dev/null; then
   bundle config set --local without 'development' ;
   # --path & --without have deprecation warnings... but for now we'll try them
   bundle install --path vendor/bundle --without development ;
+fi
+
+if [[ -n "$SOLOISTRC" && "$SOLOISTRC" != 'soloistrc' ]]; then
+  echo "INFO: Custom $SOLOISTRC passed: $SOLOISTRC"
+  if [[ -f "$SOLOISTRC" && "$(readlink soloistrc)" != "$SOLOISTRC" ]]; then
+    echo "WARN: default soloistrc file is NOT symlinked to $SOLOISTRC"
+    echo "WARN: Forcing re-link: soloistrc -> $SOLOISTRC"
+    ln -sf "$SOLOISTRC" soloistrc
+  fi
 fi
 
 # Now we provision with chef, et voilá!


### PR DESCRIPTION
Example:

```
SOLOISTRC=soloistrc.lyra bash -x /tmp/test.sh
+ SOLOISTRC=soloistrc.lyra
+ [[ -n soloistrc.lyra ]]
+ [[ soloistrc.lyra != \s\o\l\o\i\s\t\r\c ]]
+ echo 'INFO: Custom soloistrc.lyra passed: soloistrc.lyra'
INFO: Custom soloistrc.lyra passed: soloistrc.lyra
+ [[ -f soloistrc.lyra ]]
++ readlink soloistrc
+ [[ soloistrc.JamesCuzellaMBP != \s\o\l\o\i\s\t\r\c\.\l\y\r\a ]]
+ echo 'WARN: default soloistrc file is NOT symlinked to soloistrc.lyra'
WARN: default soloistrc file is NOT symlinked to soloistrc.lyra
+ echo 'WARN: Forcing re-link: soloistrc -> soloistrc.lyra'
WARN: Forcing re-link: soloistrc -> soloistrc.lyra
+ ln -sf soloistrc.lyra soloistrc
```