### PR TITLE
Add guardrails to sprout script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TEMP_PATH := $(SOLOIST_PREFIX)/tmp/
 BREWFILE_PATH ?= $(TEMP_PATH)Brewfile
 SOLOISTRC_PATH ?= $(SOLOIST_PREFIX)soloistrc
 
-.PHONY: clean librarian-clean librarian-clean-install bootstrap test
+.PHONY: clean librarian-clean librarian-clean-install bootstrap test sprout
 
 include $(SELF_DIR)/main.mk
 
@@ -36,6 +36,9 @@ librarian-clean-install: librarian-clean librarian-install ## Runs librarian-cle
 
 bootstrap: ## Run bootstrap & soloist on this node
 	./bootstrap-scripts/bootstrap.sh
+
+sprout: ## Run soloist on this node via sprout helper script
+	./sprout
 
 # Testing in /tmp first...
 .PHONY: brewfile

--- a/sprout
+++ b/sprout
@@ -1,24 +1,68 @@
 #!/usr/bin/env bash
+REPO_BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 set -e
+
+function check_sprout_locked_ruby_versions() {
+  # Check locked versions
+  sprout_ruby_version=$(cat "${REPO_BASE}/.ruby-version" | tr -d '\n')
+  sprout_ruby_gemset=$(cat "${REPO_BASE}/.ruby-gemset" | tr -d '\n')
+  sprout_rubygems_ver=$(cat "${REPO_BASE}/.rubygems-version" | tr -d '\n') ## Passed to gem update --system
+  sprout_bundler_ver=$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1 | tr -d '[:blank:]')
+}
+
+function load_rvm() {
+  if ! type rvm 2>&1 | grep -q 'rvm is a function' ; then
+    # Add RVM to PATH for scripting. Make sure this is the last PATH variable change.
+    export PATH="$PATH:$HOME/.rvm/bin"
+
+    [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm" # Load RVM into a shell session *as a function*
+  fi
+}
 
 function use_local_gems() {
   SPROUT_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   export SPROUT_HOME
-  export GEM_HOME="${SPROUT_HOME}/tmp/ruby/2.0.0"
-  export GEM_PATH="${GEM_HOME}"
-  export PATH="${GEM_HOME}/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
 
   current_ruby=$(which ruby)
-  if [ "${current_ruby}" != '/usr/bin/ruby' ]; then
-    echo -e "\033[31mWarning: sprout should be run with system ruby; using '${current_ruby}'\033[0m"
+
+  if [[ -s "$HOME/.rvm/scripts/rvm" ]]; then
+    load_rvm
+    current_rvm_ruby=$(rvm current 2>/dev/null)
+
+    check_sprout_locked_ruby_versions
+    if [[ "$current_rvm_ruby" != "ruby-${sprout_ruby_version}@${sprout_ruby_gemset}" ]]; then
+      echo -e "\033[33mWarning: current ruby '${current_ruby}' is not the same as locked .ruby-version@.ruby-gemset = 'ruby-${sprout_ruby_version}@${sprout_ruby_gemset}' \033[0m"
+      if rvm list rubies 2>/dev/null | grep -q "ruby-${sprout_ruby_version}" ; then
+        echo -e "\033[93mWarning: Changing RVM ruby to 'ruby-${sprout_ruby_version}@${sprout_ruby_gemset}' \033[0m"
+        rvm use ruby-${sprout_ruby_version}@${sprout_ruby_gemset} --create
+      else
+        echo -e "\033[31mError: Currently supported ruby-${sprout_ruby_version}@${sprout_ruby_gemset} not found!\033[0m"
+        echo -e "\033[96mInfo: Did you forget to run ./bootstrap-scripts/bootstrap.sh  ?!\033[0m"
+        echo -e "\033[31mError: Could not find a supported version of ruby; Exiting...\033[0m"
+        exit 1
+      fi
+    fi
+  elif [ "${current_ruby}" == '/usr/bin/ruby' ]; then
+    echo -e "\033[31mWarning: sprout should NO LONGER be run with system ruby; using '${current_ruby}'\033[0m"
+    echo -e "\033[31mWarning: Please review https://dontusesystemruby.com/ \033[0m"
+    echo ""
+    echo -e "\033[31mWarning: Continuing onwards... yet here be dragons! I assume you know what youre doing?\033[0m"
+
+    export GEM_HOME="${SPROUT_HOME}/tmp/ruby/2.0.0"
+    export GEM_PATH="${GEM_HOME}"
+    export PATH="${GEM_HOME}/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+  else
+    echo -e "\033[31mWarning: Could not find a supported version of ruby; Exiting...\033[0m"
+    echo -e "\033[96mInfo: Did you forget to run ./bootstrap-scripts/bootstrap.sh  ?!\033[0m"
+    exit 1
   fi
   echo "# - Using $(${current_ruby} -v)"
 }
 
 function ensure_in_sprout_home() {
   if [ "${SPROUT_HOME}" != "$(pwd)" ]; then
-    echo "Error: sprout must be run from ${SPROUT_HOME}"
+    echo "\033[91mError: sprout must be run from ${SPROUT_HOME}\033[0m"
     exit 1
   fi
 }


### PR DESCRIPTION
- Reinstating `sprout` script as a valid way to run `soloist` + `chef-solo`
- Add checks for supported RVM `$(cat .ruby-version)`@`$(cat .ruby-gemset)`
- Warn and exit with error if user has not yet run `bootstrap.sh` or setup RVM for running `./sprout`

## Breaking change...  (but Apple already broke it ... each ... and ... every ... macOS update!)

- [System Ruby is NO LONGER supported][1] for this project fork!
  - `./sprout` script will reluctantly warn you and disclaim all liability for using System Ruby.  If you choose to shoot yourself in the foot, don't blame me (or sprout)! 
  - Hopefully this ends most of the Sisyphean effort to support whichever System Ruby version Apple chooses
  - If RVM + `bootstrap.sh` becomes untenable, maybe we should consider:
    - [CInc Client bundled Ruby distribution?][2]
    - [Chef Workstation bundled Ruby distribution?][3] (already installed via `Brewfile` by `bootstrap.sh`)
    - [Chef Effortless pattern?][4]

[1]: http://dontusesystemruby.com
[2]: https://cinc.sh
[3]: https://docs.chef.io/workstation/
[4]: https://docs.chef.io/effortless/