### PR TITLE
Bootstrap rvm homebrew fixes monterey 12.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'soloist', require: false
+gem 'soloist', require: false,
+  git: 'https://github.com/trinitronx/soloist.git',
+  branch: 'develop'
 
 # >= 1.15.2 supports macOS 12.0 / Xcode 13.2
 #  ffi clang M1 compile

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'soloist', require: false,
-  git: 'https://github.com/trinitronx/soloist.git',
-  branch: 'develop'
+gem 'soloist', require: false
 
 # >= 1.15.2 supports macOS 12.0 / Xcode 13.2
 #  ffi clang M1 compile
@@ -16,6 +14,9 @@ gem 'librarian-chef', require: false
 gem 'nokogiri', require: false
 
 group :development do
+  gem 'pry', require: false
+  gem 'pry-coolline', require: false
+  gem 'pry-byebug', require: false
   gem 'bundler', require: false
   gem 'guard', require: false
   gem 'guard-rspec', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,12 @@ GIT
   revision: 535584a4e375905bb97afbc482b15ca86d3b23f7
   branch: develop
   specs:
-    soloist (2.0.0alpha)
+    soloist (1.0.3)
+      awesome_print
       chef
-      chef-bin
-      chef-zero
+      hashie (~> 2.0)
       librarian-chef
+      net-ssh
       thor
 
 GEM
@@ -217,13 +218,6 @@ GEM
       specinfra (~> 2.72)
     sfl (2.3)
     shellany (0.0.1)
-    soloist (1.0.3)
-      awesome_print
-      chef
-      hashie (~> 2.0)
-      librarian-chef
-      net-ssh
-      thor
     specinfra (2.83.1)
       net-scp
       net-ssh (>= 2.7)
@@ -242,6 +236,7 @@ GEM
 PLATFORMS
   ruby
   universal-darwin-20
+  x86_64-darwin-19
 
 DEPENDENCIES
   bundler
@@ -259,7 +254,7 @@ DEPENDENCIES
   plist
   rspec
   rubocop
-  soloist
+  soloist!
 
 BUNDLED WITH
    2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,6 +237,7 @@ PLATFORMS
   ruby
   universal-darwin-20
   x86_64-darwin-19
+  x86_64-linux
 
 DEPENDENCIES
   bundler

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/trinitronx/soloist.git
+  revision: 535584a4e375905bb97afbc482b15ca86d3b23f7
+  branch: develop
+  specs:
+    soloist (2.0.0alpha)
+      chef
+      chef-bin
+      chef-zero
+      librarian-chef
+      thor
+
 GEM
   remote: https://rubygems.org/
   specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/trinitronx/soloist.git
-  revision: 535584a4e375905bb97afbc482b15ca86d3b23f7
-  branch: develop
-  specs:
-    soloist (1.0.3)
-      awesome_print
-      chef
-      hashie (~> 2.0)
-      librarian-chef
-      net-ssh
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -19,6 +6,7 @@ GEM
     ast (2.4.2)
     awesome_print (1.9.2)
     builder (3.2.4)
+    byebug (11.1.3)
     chef (13.10.0)
       addressable
       bundler (>= 1.10)
@@ -66,13 +54,15 @@ GEM
       fauxhai (>= 4)
       rspec (~> 3.0)
     coderay (1.1.3)
-    diff-lcs (1.4.4)
+    coolline (0.5.0)
+      unicode_utils (~> 1.4)
+    diff-lcs (1.5.0)
     erubis (2.7.0)
     fauxhai (6.0.1)
       net-ssh
-    ffi (1.15.4)
-    ffi-yajl (2.3.1)
-      libyajl2 (~> 1.2)
+    ffi (1.15.5)
+    ffi-yajl (2.4.0)
+      libyajl2 (>= 1.2)
     foodcritic (16.3.0)
       erubis
       ffi-yajl (~> 2.0)
@@ -115,13 +105,12 @@ GEM
       chef (>= 0.10)
       librarian (~> 0.1.0)
       minitar (>= 0.5.2)
-    libyajl2 (1.2.0)
-    listen (3.7.0)
+    libyajl2 (2.1.0)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.8)
     method_source (1.0.0)
-    mini_portile2 (2.4.0)
     minitar (0.9)
     mixlib-archive (0.4.20)
       mixlib-log
@@ -144,8 +133,12 @@ GEM
       net-ssh (>= 2.6.5)
       net-ssh-gateway (>= 1.2.0)
     net-telnet (0.1.1)
-    nokogiri (1.10.4)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.13.1-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -162,7 +155,7 @@ GEM
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
     parallel (1.21.0)
-    parser (3.0.3.2)
+    parser (3.1.0.0)
       ast (~> 2.4.1)
     plist (3.6.0)
     polyglot (0.3.5)
@@ -170,9 +163,16 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-coolline (0.2.6)
+      coolline (~> 0.5)
+      pry (~> 0.13)
     public_suffix (4.0.6)
+    racc (1.6.0)
     rack (2.2.3)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -198,16 +198,16 @@ GEM
     rspec_junit_formatter (0.2.3)
       builder (< 4)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.23.0)
+    rubocop (1.24.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml
-      rubocop-ast (>= 1.12.0, < 2.0)
+      rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.15.0)
+    rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
     ruby-progressbar (1.11.0)
     rufus-lru (1.1.0)
@@ -218,6 +218,13 @@ GEM
       specinfra (~> 2.72)
     sfl (2.3)
     shellany (0.0.1)
+    soloist (1.0.3)
+      awesome_print
+      chef
+      hashie (~> 2.0)
+      librarian-chef
+      net-ssh
+      thor
     specinfra (2.83.1)
       net-scp
       net-ssh (>= 2.7)
@@ -230,11 +237,12 @@ GEM
     treetop (1.6.11)
       polyglot (~> 0.3)
     unicode-display_width (2.1.0)
+    unicode_utils (1.4.0)
     uuidtools (2.1.5)
     wmi-lite (1.0.5)
 
 PLATFORMS
-  ruby
+  arm64-darwin-21
   universal-darwin-20
   x86_64-darwin-19
   x86_64-linux
@@ -253,9 +261,12 @@ DEPENDENCIES
   librarian-chef
   nokogiri
   plist
+  pry
+  pry-byebug
+  pry-coolline
   rspec
   rubocop
-  soloist!
+  soloist
 
 BUNDLED WITH
-   2.2.33
+   2.3.4

--- a/bootstrap-scripts/bootstrap.sh
+++ b/bootstrap-scripts/bootstrap.sh
@@ -445,6 +445,8 @@ if [[ -n "$SOLOISTRC" && "$SOLOISTRC" != 'soloistrc' ]]; then
   fi
 fi
 
+# Auto-accept Chef license for non-interactive automation
+export CHEF_LICENSE=accept
 # Now we provision with chef, et voilá!
 # Node, it's time you grew up to who you want to be
 caffeinate -dimsu bundle exec soloist || errorout "Soloist provisioning failed!"

--- a/bootstrap-scripts/bootstrap.sh
+++ b/bootstrap-scripts/bootstrap.sh
@@ -95,8 +95,24 @@ function rvm_set_compile_opts() {
     export DLDFLAGS="-L/opt/homebrew/opt/libffi/lib"
     export CPPFLAGS="-I/opt/homebrew/opt/libffi/include"
     export PKG_CONFIG_PATH="/opt/homebrew/opt/libffi/lib/pkgconfig"
+    bundle config build.ffi --enable-system-libffi
+  fi
+
+  if [[ "$RVM_COMPILE_OPTS_M1_NOKOGIRI" == "1" ]]; then
+    bundle config build.nokogiri --platform=ruby -- --use-system-libraries
   fi
   turn_trace_off
+}
+
+function brew_install_rvm_libs() {
+  if [[ "$BREW_INSTALL_LIBFFI" == "1" ]]; then
+    grep -q 'libffi' Brewfile || echo "brew 'libffi'" >> Brewfile
+  fi
+  if [[ "$BREW_INSTALL_NOKOGIRI_LIBS" == "1" ]]; then
+    grep -q 'libxml2' Brewfile || echo "brew 'libxml2'" >> Brewfile
+    grep -q 'libxslt' Brewfile || echo "brew 'libxslt'" >> Brewfile
+    grep -q 'libiconv' Brewfile || echo "brew 'libiconv'" >> Brewfile
+  fi
 }
 
 function rvm_install_ruby_and_gemset() {
@@ -171,7 +187,8 @@ detect_platform_version
 # https://developer.apple.com/downloads/index.action
 case $platform_version in
   12.0*|12.1*)
-          XCODE_DMG='Xcode_13.2.xip'; export TRY_XCI_OSASCRIPT_FIRST=1; BREW_INSTALL_LIBFFI=1; RVM_COMPILE_OPTS_M1_LIBFFI=1 ;;
+          XCODE_DMG='Xcode_13.2.xip'; export TRY_XCI_OSASCRIPT_FIRST=1; BREW_INSTALL_LIBFFI=1; RVM_COMPILE_OPTS_M1_LIBFFI=1 ;
+          BREW_INSTALL_NOKOGIRI_LIBS="1" ; RVM_COMPILE_OPTS_M1_NOKOGIRI=1 ;;
   11.6*)  XCODE_DMG='Xcode_13.1.xip'; export TRY_XCI_OSASCRIPT_FIRST=1; export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ;;
   10.15*) XCODE_DMG='Xcode_12.4.xip'; export INSTALL_SDK_HEADERS=1 ; export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ;;
   10.14*) XCODE_DMG='Xcode_11_GM_Seed.xip'; export INSTALL_SDK_HEADERS=1 ; export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES ;;
@@ -308,9 +325,7 @@ if [[ "$INSTALL_SDK_HEADERS" == '1' ]]; then
   fi
 fi
 
-if [[ "$BREW_INSTALL_LIBFFI" == "1" ]]; then
-  echo "brew 'libffi'" >> Brewfile
-fi
+brew_install_rvm_libs
 
 if [[ "$CI" == 'true' ]]; then
   echo "INFO: CI run detected via \$CI=$CI env var"


### PR DESCRIPTION
 - Update `soloist` to unpin it's dependencies
 - Add build flags for `libffi` & `nokogiri` on macOS `12.1` Monterey
 - Auto-accept Chef Infra license for unattended `bootstrap.sh` runs