### PR TITLE
CI soloistrc: Disable sprout-osx-settings::updates using touchfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
           sudo tee -a ~root/.profile <<EOPROFILE
           SSH_AUTH_SOCK=${{ env.SSH_AUTH_SOCK }}
           EOPROFILE
-          cat ~root/.profile
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           sudo tee -a ~root/.profile <<EOPROFILE
           SSH_AUTH_SOCK=${{ env.SSH_AUTH_SOCK }}
           EOPROFILE
+          cat ~root/.profile
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,9 @@ jobs:
           sudo sysctl -w net.link.generic.system.hwcksum_tx=1
           sudo sysctl -w net.link.generic.system.hwcksum_rx=1
       - name: Disable sprout-osx-settings::updates
-        run: sudo touch /var/chef/cache/last_software_update
+        run: |
+          sudo mkdir -p /var/chef/cache/
+          sudo touch /var/chef/cache/last_software_update
       - name: Run bootstrap.sh + soloist with test fixtures
         run: |
           make bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,8 @@ jobs:
         run: |
           sudo sysctl -w net.link.generic.system.hwcksum_tx=1
           sudo sysctl -w net.link.generic.system.hwcksum_rx=1
+      - name: Disable sprout-osx-settings::updates
+        run: sudo touch /var/chef/cache/last_software_update
       - name: Run bootstrap.sh + soloist with test fixtures
         run: |
           make bootstrap

--- a/TODO.md
+++ b/TODO.md
@@ -68,6 +68,20 @@ Misc
   - Cons:
     - Not as easy to push changes back upstream (if it becomes active again)
     - Not as much community support (if it becomes active again)
+  - Alternative "sprout"-themed name brainstorming:
+    - sprig
+    - shoot (too generic, has alternate meaning)
+    - twig
+    - seed
+    - seedling
+    - sapling
+    - plant
+    - leaf
+    - cotyledon
+  - "sprout-wrap" Alternatives:
+    - exocarp
+    - seed-coat
+    - endocarp
 - Update GitHub `known_hosts` keys to use [their newer public key algorithms][7]:
 - ECDSA:
 - Ed25519:


### PR DESCRIPTION
- Disables [`sprout-osx-settings::updates`][1] in CI by touching `/var/chef/cache/last_software_update` file

[1]: https://github.com/pivotal-sprout/sprout-osx-settings/blob/master/recipes/updates.rb#L4