### PR TITLE
Fix GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Run bootstrap.sh + soloist with test fixtures
         run: |
           make bootstrap
-      - name: DEBUG - Where are Brewfiles?
+      - name: DEBUG - Where are Brewfiles? (exclude nodes and vendor dirs)
         run: |
-          find ${GITHUB_WORKSPACE} -iname 'Brewfile*'
+          find ${GITHUB_WORKSPACE} \( -type d -a \( -name '*/nodes' -o -name '*/vendor' \) -prune \) -o -iname 'Brewfile*'
         if: env.debug_ci == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
         if: env.debug_ci == 'true'
       - name: Generate Brewfile from soloistrc test fixture
         run: make brewfile
+      - name: DEBUG - Where are Brewfiles?
+        run: |
+          find ${GITHUB_WORKSPACE} -iname 'Brewfile*'
+        if: env.debug_ci == 'true'
       - name: Configure Homebrew cache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,7 @@ jobs:
       - name: Run bootstrap.sh + soloist with test fixtures
         run: |
           make bootstrap
+      - name: DEBUG - Where are Brewfiles?
+        run: |
+          find ${GITHUB_WORKSPACE} -iname 'Brewfile*'
+        if: env.debug_ci == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,6 @@ jobs:
           make bootstrap
       - name: DEBUG - Where are Brewfiles? (exclude nodes and vendor dirs)
         run: |
+          sudo chown -R $(id -u):$(id -g) ${GITHUB_WORKSPACE}/test/fixtures/nodes
           find ${GITHUB_WORKSPACE} \( -type d -a \( -name '*/nodes' -o -name '*/vendor' \) -prune \) -o -iname 'Brewfile*'
         if: env.debug_ci == 'true'


### PR DESCRIPTION
CI was failing on Homebrew cache step... because it couldn't find the `Brewfile.ci` and/or `**/Brewfile.lock.json` to use for cache key `hashFiles(...)`