### PR TITLE
soloistrc.E0000002021: Add eksctl, argocd, zoom via Homebrew

### DIFF
--- a/soloistrc.E0000002021.yml
+++ b/soloistrc.E0000002021.yml
@@ -199,6 +199,8 @@ node_attributes:
       - kubernetes-cli
       - kubectx
       - kops
+      - eksctl
+      - argocd
       - minikube
       - imagemagick
       - openssl
@@ -295,6 +297,7 @@ node_attributes:
       - hex-fiend
       - beyond-compare
       - rar
+      - zoom
       ## Commented out until they update to Sublime Text 3
       - sublime-text
       - meld


### PR DESCRIPTION
Adding some manually installed Casks to keep the `soloistrc` up to date