### PR TITLE
git-flow-automerge: Debug git rev-parse master SHA

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -13,10 +13,9 @@ jobs:
   debug-automerge:
     runs-on: ubuntu-latest
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+      - uses: actions/checkout@v3
+      - name: Dump master SHA
+        run: git rev-parse master
   automerge:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest

--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -10,18 +10,23 @@ on:
     types: [ labeled, closed, edited ]
 
 jobs:
-  debug-automerge:
+  master-branch:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           ref: master
-      - name: Dump master SHA
-        run: git rev-parse master
+      - name: Extract master SHA
+        run: echo "::set-output name=sha::$(git rev-parse master)"
+        id: master_branch
+    outputs:
+      sha: ${{ steps.master_branch.outputs.sha }}
   automerge:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest
     steps:
+      - name: Debug Master SHA
+        run: echo ${{ needs.master-branch.outputs.sha }}
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
@@ -42,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           branch: ${{ steps.chef_release.outputs.branch }}
-          sha: master
+          sha: ${{ needs.master-branch.outputs.sha }}
       - name: git-flow-merge-action
         uses: yanamura/git-flow-merge-action@v1
         with:

--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 2
+          ref: master
       - name: Dump master SHA
         run: git rev-parse master
   automerge:

--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - name: Dump master SHA
         run: git rev-parse master
   automerge:

--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -10,6 +10,13 @@ on:
     types: [ labeled, closed, edited ]
 
 jobs:
+  debug-automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
   automerge:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Get and pass `master` branch SHA to the actions-create-branch step... so we can always create new `release/chef-v*` branches off of `master`