### PR TITLE
soloistrc.{lyra,E01104,E02021}: Disable iTerm2 Shell Integration due to slow __bp_preexec_invoke_exec() bash-completion issue

### DIFF
--- a/soloistrc.E0000001104.yml
+++ b/soloistrc.E0000001104.yml
@@ -81,7 +81,7 @@ recipes:
   # - lyraphase_workstation::bash4
   - lyraphase_workstation::bash_it_custom_plugins
   - lyraphase_workstation::iterm2
-  - lyraphase_workstation::iterm2_shell_integration
+  # - lyraphase_workstation::iterm2_shell_integration ## JMC 2022-02-13: Disabled due to slow __bp_preexec_invoke_exec() bash-completion issue
 
 node_attributes:
   bash_it:

--- a/soloistrc.E0000002021.yml
+++ b/soloistrc.E0000002021.yml
@@ -81,7 +81,7 @@ recipes:
   # - lyraphase_workstation::bash4
   - lyraphase_workstation::bash_it_custom_plugins
   - lyraphase_workstation::iterm2
-  - lyraphase_workstation::iterm2_shell_integration
+  # - lyraphase_workstation::iterm2_shell_integration ## JMC 2022-02-13: Disabled due to slow __bp_preexec_invoke_exec() bash-completion issue
 
 node_attributes:
   bash_it:

--- a/soloistrc.lyra.yml
+++ b/soloistrc.lyra.yml
@@ -78,7 +78,7 @@ recipes:
 
 ### Lyraphase Workstation & Custom
 - lyraphase_workstation::iterm2
-- lyraphase_workstation::iterm2_shell_integration
+#- lyraphase_workstation::iterm2_shell_integration ## JMC 2022-02-13: Disabled due to slow __bp_preexec_invoke_exec() bash-completion issue
 - lyraphase_workstation::airfoil
 - lyraphase_workstation::ableton_live
 - lyraphase_workstation::ableton_live_options


### PR DESCRIPTION
Background: Bash Tab-completion & initial startup recently became very slow.  Time-profiling turned up the following culprits:


```bash
0.322648 s: :20: __bp_preexec_invoke_exec '/Volumes/test-volume/Latest'
0.263528 s: /Users/exampleuser/.bash_it/themes/base.theme.bash:135: rvm_version_prompt():rvm=ruby-2.4.0
0.118152 s: /usr/local/etc/bash_completion:73: _filedir(): '[' 2 -ne 0 ']'
0.070424 s: /Users/exampleuser/.iterm2_shell_integration.bash:6: __bp_preexec_invoke_exec((( __bp_inside_preexec > 0 ))
0.044204 s: /Users/exampleuser/.bash_it/lib/helpers.bash:1: _is_function(): _about 'sets $? to true if parameter is the name of a function'
0.039965 s: /Users/exampleuser/.bash_it/vendor/github.com/erichs/composure/composure.sh:0:
0.0383 s: /Users/exampleuser/.iterm2_shell_integration.bash:23: __bp_preexec_invoke_exec[[ -z on ]]
0.033461 s: /Users/exampleuser/.iterm2_shell_integration.bash:33: __bp_preexec_invoke_exec[[ 0 -eq 0 ]]
0.032788 s: /Users/exampleuser/.bash_it/lib/helpers.bash:-243: _command_exists(): local 'msg=Command '\''rbenv'\'' does not exist'
0.032448 s: :20: __bp_preexec_invoke_exec _filedir
0.031016 s: /Users/exampleuser/.iterm2_shell_integration.bash:3: __bp_in_prompt_command():IFS='
0.030228 s: /Users/exampleuser/.iterm2_shell_integration.bash:74: __bp_in_prompt_command()__bp_trim_whitespace trimmed_command __bp_precmd_invoke_cmd
0.030165 s: /Users/exampleuser/.iterm2_shell_integration.bash:9: __bp_preexec_invoke_exec(local __bp_inside_preexec=1
0.029138 s: /Users/exampleuser/.bash_it/lib/helpers.bash:-239: _command_exists(): _log_debug 'Command '\''rbenv'\'' does not exist'
0.029076 s: /Users/exampleuser/.bash_it/lib/helpers.bash:1031: _bash-it-find-in-ancestor(for kin in '"$@"'
0.028654 s: /usr/local/etc/bash_completion:294: __reassemble_comp_words_by_ref(): (( i++, j++ ))
0.028564 s: /Users/exampleuser/.iterm2_shell_integration.bash:14: __bp_preexec_invoke_exe[[ ! -t 1 ]]
0.027954 s: /Users/exampleuser/.iterm2_shell_integration.bash:72: __bp_in_prompt_command()local command trimmed_command
0.027951 s: /usr/local/etc/bash_completion:21: __reassemble_comp_words_by_ref(): [[ '' == /Volumes/test-volume/La ]]
0.02661 s: /usr/local/etc/bash_completion:66: _filedir(): [[ '' != -d ]]
```

Disabling `.iterm2_shell_integration.bash` fixed the issue.

Time profiling data generated by:

```bash
function date_hires() {     \gdate "+%s.%N"; }
export PS4='+ $(date_hires) ${BASH_SOURCE}:${LINENO}: ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
exec 3>&2 2>/tmp/bashstart.$$.log ; set -x ;
ls -lA /Volumes/test-volume/La ## [TAB-completion triggered here on "Latest"]
set +x; exec 2>&3 3>&-

# Ran python timestamp analysis script on resulting time profile logfile:
~/bin/analyze-slow-bashrc-bashstart.py /tmp/bashstart.83514.log
```