### PR TITLE
git-flow-automerge: Debug GitHub actions boolean statement

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -34,6 +34,22 @@ jobs:
     outputs:
       sha: ${{ steps.master_branch.outputs.sha }}
       authorized: ${{ steps.check_user_permissions.outputs.require-result }}
+  debug-automerge:
+    runs-on: ubuntu-latest
+    needs: master-branch
+    steps:
+      - name: Debug needs.master-branch.outputs.authorized
+        run: echo ${{ needs.master-branch.outputs.authorized }}
+      - name: Debug Authorized == true
+        run: echo DEBUG AUTHZ = ${{ needs.master-branch.outputs.authorized == true }}
+      - name: Debug Authorized fromJson
+        run: echo DEBUG AUTHZ = ${{ fromJSON(needs.master-branch.outputs.authorized) }}
+      - name: Debug Authorized fromJson to Boolean ... fromJSON(needs.master-branch.outputs.authorized) == true
+        run: echo DEBUG AUTHZ = ${{ fromJSON(needs.master-branch.outputs.authorized) == true }}
+      - name: Debug Authorized cast to String, then boolean check ...format('{0}', needs.master-branch.outputs.authorized) == 'true'
+        run: echo DEBUG AUTHZ = ${{ format('{0}', needs.master-branch.outputs.authorized) == 'true' }}
+      - name: Debug FULL Boolean
+        run: echo DEBUG BOOLEAN = ${{ needs.master-branch.outputs.authorized == true && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release') }}
   automerge:
     if: needs.master-branch.outputs.authorized == true && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest

--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Debug FULL Boolean
         run: echo DEBUG BOOLEAN = ${{ needs.master-branch.outputs.authorized == true && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release') }}
   automerge:
-    if: needs.master-branch.outputs.authorized == true && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
+    if: format('{0}', needs.master-branch.outputs.authorized) == 'true' && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest
     needs: master-branch
     steps:


### PR DESCRIPTION
Output from `actions-cool/check-user-permission@v2.2.0` is passed as `String` into GitHub Actions eval expression context.

Turns out that we can either use `fromJson(foo)` to typecast to Boolean, and hope it always returns a Boolean via `true` / `false` JSON syntax... OR we can typecast to String using `format('{0}', foo)` and compare as a String.

Seems that the most deterministic type-safe way is probably to typecast to `String`