### PR TITLE
fix automerge ci permissions

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -50,6 +50,11 @@ jobs:
         run: echo DEBUG AUTHZ = ${{ format('{0}', needs.master-branch.outputs.authorized) == 'true' }}
       - name: Debug FULL Boolean
         run: echo DEBUG BOOLEAN = ${{ format('{0}', needs.master-branch.outputs.authorized) == 'true' && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release') }}
+      - name: Debug Boolean Parts
+        run: |
+          echo DEBUG github.event.pull_request.merged == true  = ${{ github.event.pull_request.merged == true }}
+          echo DEBUG github.event.pull_request.labels.*.name contains? 'release' = ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
+          echo DEBUG github.event.label.name == 'release' = ${{ github.event.label.name == 'release' }}
   automerge:
     if: format('{0}', needs.master-branch.outputs.authorized) == 'true' && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Test deploying `develop` via automerge workflow into `master`:

- soloistrc.lyra: Add exa via Homebrew
- Update FUNDING.yml
- Debug GitHub actions 'github' context
- git-flow-automerge: Check triggering user authz for perms >= write
- git-flow-automerge: Debug GitHub actions 'github' context
- git-flow-automerge: eval 'github.triggering_actor'
- git-flow-automerge: Switch to using new fine-grained secret token
- git-flow-automerge: Debug GitHub actions boolean statement
- git-flow-automerge: Compare authz step output as String
- git-flow-automerge: DEBUG: Compare authz step output as String
- git-flow-automerge: Set permissions at job-level
- Revert "git-flow-automerge: Set permissions at job-level"
- git-flow-automerge: DEBUG: Print all boolean parts
