### PR TITLE
fix automerge ci permissions

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -19,11 +19,6 @@ jobs:
       - name: Extract master SHA
         run: echo "::set-output name=sha::$(git rev-parse master)"
         id: master_branch
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT" | jq '.'
       - name: Check triggering user permissions
         id: check_user_permissions
         uses: actions-cool/check-user-permission@v2.2.0
@@ -34,39 +29,11 @@ jobs:
     outputs:
       sha: ${{ steps.master_branch.outputs.sha }}
       authorized: ${{ steps.check_user_permissions.outputs.require-result }}
-  debug-automerge:
-    runs-on: ubuntu-latest
-    needs: master-branch
-    steps:
-      - name: Debug needs.master-branch.outputs.authorized
-        run: echo ${{ needs.master-branch.outputs.authorized }}
-      - name: Debug Authorized == true
-        run: echo DEBUG AUTHZ = ${{ needs.master-branch.outputs.authorized == true }}
-      - name: Debug Authorized fromJson
-        run: echo DEBUG AUTHZ = ${{ fromJSON(needs.master-branch.outputs.authorized) }}
-      - name: Debug Authorized fromJson to Boolean ... fromJSON(needs.master-branch.outputs.authorized) == true
-        run: echo DEBUG AUTHZ = ${{ fromJSON(needs.master-branch.outputs.authorized) == true }}
-      - name: Debug Authorized cast to String, then boolean check ...format('{0}', needs.master-branch.outputs.authorized) == 'true'
-        run: echo DEBUG AUTHZ = ${{ format('{0}', needs.master-branch.outputs.authorized) == 'true' }}
-      - name: Debug FULL Boolean
-        run: echo DEBUG BOOLEAN = ${{ format('{0}', needs.master-branch.outputs.authorized) == 'true' && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release') }}
-      - name: Debug Boolean Parts
-        run: |
-          echo DEBUG github.event.pull_request.merged == true  = ${{ github.event.pull_request.merged == true }}
-          echo DEBUG github.event.pull_request.labels.*.name contains? 'release' = ${{ contains(github.event.pull_request.labels.*.name, 'release') }}
-          echo DEBUG github.event.label.name == 'release' = ${{ github.event.label.name == 'release' }}
   automerge:
     if: format('{0}', needs.master-branch.outputs.authorized) == 'true' && github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'release') || github.event.label.name == 'release')
     runs-on: ubuntu-latest
     needs: master-branch
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          echo "$GITHUB_CONTEXT" | jq '.'
-      - name: Debug Master SHA
-        run: echo ${{ needs.master-branch.outputs.sha }}
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
- git-flow-automerge: Check triggering user authz for perms >= write
- git-flow-automerge: Debug GitHub actions 'github' context
- git-flow-automerge: eval 'github.triggering_actor'
- git-flow-automerge: Switch to using new fine-grained secret token
- git-flow-automerge: Debug GitHub actions boolean statement
- git-flow-automerge: Compare authz step output as String
- git-flow-automerge: DEBUG: Compare authz step output as String
- git-flow-automerge: Set permissions at job-level
- Revert "git-flow-automerge: Set permissions at job-level"
- git-flow-automerge: DEBUG: Print all boolean parts
- 🚧 REVERTME TO DEBUG - git-flow-automerge: Remove DEBUG
