### PR TITLE
ci: add paulxstretch to CI soloistrc

### DIFF
--- a/test/fixtures/soloistrc
+++ b/test/fixtures/soloistrc
@@ -140,6 +140,7 @@ node_attributes:
       - lsusb
     casks:
       - bpm
+      - paulxstretch
 
   workspace_directory: src
   vim_alias_vi_to_minimal_vim: false


### PR DESCRIPTION
`master` branch needed bump of `test/fixtures/*` to recheck `ci` workflow & enable success badge

Errors were:

```
[2023-10-07T00:52:43+00:00] ERROR: Cookbook 'homebrew' version '5.3.8' depends on chef version [">= 15.3"], but the running chef version is 13.10.0
[2023-10-07T00:52:43+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
+(./bootstrap-scripts/bootstrap.sh:570): errorout 'Soloist provisioning failed!'
ERROR: Soloist provisioning failed!
```

Requires Chef version upgrade. Dependent on #158