### PR TITLE
Migrate blackhole cask

### DIFF
--- a/soloistrc.lyra.yml
+++ b/soloistrc.lyra.yml
@@ -278,7 +278,7 @@ node_attributes:
       - audio-hijack
       - loopback
       - keyfinder
-      - blackhole
+      - blackhole-16ch
       - elektron-overbridge
       - elektron-transfer
       - paulxstretch

--- a/test/fixtures/soloistrc
+++ b/test/fixtures/soloistrc
@@ -140,6 +140,7 @@ node_attributes:
       - lsusb
     casks:
       - bpm
+      - paulxstretch
 
   workspace_directory: src
   vim_alias_vi_to_minimal_vim: false


### PR DESCRIPTION
Blackhole Cask has been [split into different builds][1].

We had been using the `16ch` version, so switch to that.

[1]: https://github.com/ExistentialAudio/BlackHole?tab=readme-ov-file#option-2-install-via-homebrew