### PR TITLE
soloistrc.lyra: Add ansible-lint via Homebrew

### DIFF
--- a/soloistrc.lyra.yml
+++ b/soloistrc.lyra.yml
@@ -225,6 +225,7 @@ node_attributes:
       - pre-commit
       - shellcheck
       - yamllint
+      - ansible-lint
       - tmux
 # For pbcopy to work in tmux: http://evertpot.com/osx-tmux-vim-copy-paste-clipboard/
 # Also fixes Sublime Text "subl" command not working


### PR DESCRIPTION
For Sublime Text 4 plugin: [`SublimeLinter-contrib-ansible-lint`][1]

[1]: https://packagecontrol.io/packages/SublimeLinter-contrib-ansible-lint