### PR TITLE
soloistrc.lyra: Add chezmoi via Homebrew

### DIFF
--- a/soloistrc.lyra.yml
+++ b/soloistrc.lyra.yml
@@ -201,6 +201,7 @@ node_attributes:
     formulas:
       - bash-completion
 #      - ctags-exuberant
+      - chezmoi
       - ag
       - exa
       - gptfdisk


### PR DESCRIPTION
Towards fixing LyraPhase/lyraphase_workstation#102 (possible migration path away from Chef for simple template-able configs)