### PR TITLE
Fix #203: Migrate from ::set-output to using $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: master
       - name: Extract master SHA
-        run: echo "::set-output name=sha::$(git rev-parse master)"
+        run: echo "sha=$(git rev-parse master)" >> "$GITHUB_OUTPUT"
         id: master_branch
       - name: Check triggering user permissions
         id: check_user_permissions
@@ -43,11 +43,11 @@ jobs:
         run: |
           bundle exec gem list --quiet --local --exact 'chef' | \
           ruby -ne 'version = gsub(/chef\s*\((?<version>.*)\)$/, %q/\k<version>/); \
-                    print "::set-output name=chef_version::#{version.chomp}"'
+                    print "chef_version=#{version.chomp}"' >> "$GITHUB_OUTPUT"
         id: extract_chef_version
       - name: Set release/chef-version branch name
         run: |
-          echo '::set-output name=branch::release/chef-v${{ steps.extract_chef_version.outputs.chef_version }}'
+          echo 'branch=release/chef-v${{ steps.extract_chef_version.outputs.chef_version }}' >> "$GITHUB_OUTPUT"
         id: chef_release
       - uses: peterjgrainger/action-create-branch@v2.2.0
         env:


### PR DESCRIPTION
References:

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/

> 24-July-2023 Update: Our telemetry shows significant usage of these commands
> so we have decided to postpone the removal. To learn more, visit the latest
> changelog post.