### PR TITLE
Update gha workflows to Node 20

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -21,7 +21,7 @@ jobs:
         id: master_branch
       - name: Check triggering user permissions
         id: check_user_permissions
-        uses: actions-cool/check-user-permission@v2.2.0
+        uses: actions-cool/check-user-permission@v2.2.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.triggering_actor }}

--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -56,7 +56,7 @@ jobs:
           branch: ${{ steps.chef_release.outputs.branch }}
           sha: ${{ needs.master-branch.outputs.sha }}
       - name: git-flow-merge-action
-        uses: yanamura/git-flow-merge-action@v1
+        uses: yanamura/git-flow-merge-action@v1.4.0
         with:
           github_token: ${{ secrets.LYRAPHASE_RUNNER_AUTOMERGE_TOKEN }}
           branch: 'develop'


### PR DESCRIPTION
Bumping versions of GitHub Actions workflows that had warnings...

## Annotations
<div class="color-fg-muted text-small">2 warnings</div>

---

> [!WARNING]
> The following actions uses Node.js version which is deprecated and will be forced to run on node20: yanamura/git-flow-merge-action@v1. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
> 
> - **[master-branch](https://github.com/LyraPhase/sprout-wrap/actions/runs/10261688917/job/28389888584)**
> - **[automerge](https://github.com/LyraPhase/sprout-wrap/actions/runs/10261688917/job/28389893504)**
