### PR TITLE
Update gha git flow merge node 20

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -56,7 +56,7 @@ jobs:
           branch: ${{ steps.chef_release.outputs.branch }}
           sha: ${{ needs.master-branch.outputs.sha }}
       - name: git-flow-merge-action
-        uses: yanamura/git-flow-merge-action@v1.4.0
+        uses: yanamura/git-flow-merge-action@9d4a90b72af5df91efa8db230273c95f57dd8d05
         with:
           github_token: ${{ secrets.LYRAPHASE_RUNNER_AUTOMERGE_TOKEN }}
           branch: 'develop'


### PR DESCRIPTION
Node 20 upgrade fixed in: yanamura/git-flow-merge-action@bc737447c0dc634d6656204299592a583f4259e8

Bump to latest `master` branch `HEAD`: yanamura/git-flow-merge-action@9d4a90b72af5df91efa8db230273c95f57dd8d05