### PR TITLE
gha: Force automerge workflow to use Node 20

### DIFF
--- a/.github/workflows/git-flow-automerge.yml
+++ b/.github/workflows/git-flow-automerge.yml
@@ -9,6 +9,9 @@ on:
     branches: [ develop ]
     types: [ labeled, closed, edited ]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
+
 jobs:
   master-branch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Test by forcing GitHub Actions to use Node.js 20